### PR TITLE
Implement RFT upload API

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@supabase/supabase-js": "^2.49.4",
     "@tanstack/react-query": "^5.56.2",
     "@testing-library/user-event": "^14.6.1",
+    "formidable": "^3.5.2",
     "caniuse-lite": "^1.0.30001715",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/components/FileUploader.test.tsx
+++ b/src/components/FileUploader.test.tsx
@@ -25,6 +25,7 @@ describe('FileUploader minimal render', () => {
 describe('FileUploader', () => {
   const mockSetStatus = vi.fn();
   const mockSetStoreId = vi.fn();
+  const mockSetTaskId = vi.fn();
   const mockSetError = vi.fn();
   const mockOnUploaded = vi.fn();
 
@@ -36,15 +37,17 @@ describe('FileUploader', () => {
       status: 'idle',
       error: null,
       storeId: null,
+      taskId: null,
       setStatus: mockSetStatus,
       setStoreId: mockSetStoreId,
+      setTaskId: mockSetTaskId,
       setError: mockSetError,
     });
 
     // Mock fetch response
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ storeId: 'test-store-id' }),
+      json: () => Promise.resolve({ storeId: 'test-store-id', taskId: 'test-task-id' }),
     });
   });
 
@@ -128,6 +131,7 @@ describe('FileUploader', () => {
 
       expect(mockSetStatus).toHaveBeenCalledWith('uploaded');
       expect(mockSetStoreId).toHaveBeenCalledWith('test-store-id');
+      expect(mockSetTaskId).toHaveBeenCalledWith('test-task-id');
       expect(mockOnUploaded).toHaveBeenCalledWith('test-store-id');
     });
   });

--- a/src/components/FileUploader.tsx
+++ b/src/components/FileUploader.tsx
@@ -17,7 +17,7 @@ const MAX_SIZE = 20 * 1024 * 1024; // 20MB
 export const FileUploader: React.FC<FileUploaderProps> = ({ onUploaded }) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const [progress, setProgress] = useState(0);
-  const { status, setStatus, setStoreId, setError, error } = useAppStore();
+  const { status, setStatus, setStoreId, setTaskId, setError, error } = useAppStore();
   const [filename, setFilename] = useState<string | null>(null);
 
   function handleInputChange(e: React.ChangeEvent<HTMLInputElement>) {
@@ -38,6 +38,7 @@ export const FileUploader: React.FC<FileUploaderProps> = ({ onUploaded }) => {
   function validateAndUpload(file: File) {
     setError(null);
     setStoreId(null);
+    setTaskId(null);
 
     if (!ACCEPTED_TYPES.includes(file.type)) {
       setError('Only PDF or DOCX files are allowed.');
@@ -88,6 +89,7 @@ export const FileUploader: React.FC<FileUploaderProps> = ({ onUploaded }) => {
       setProgress(100);
       setStatus('uploaded');
       setStoreId(data.storeId);
+      if (data.taskId) setTaskId(data.taskId);
       if (onUploaded) onUploaded(data.storeId);
     } catch (err: any) {
       setStatus('error');
@@ -99,6 +101,7 @@ export const FileUploader: React.FC<FileUploaderProps> = ({ onUploaded }) => {
   function resetUpload() {
     setStatus('idle');
     setStoreId(null);
+    setTaskId(null);
     setError(null);
     setProgress(0);
     setFilename(null);

--- a/src/hooks/useAppStore.ts
+++ b/src/hooks/useAppStore.ts
@@ -4,18 +4,22 @@ type UploadStatus = 'idle' | 'uploading' | 'uploaded' | 'error';
 
 interface AppState {
   storeId: string | null;
+  taskId: string | null;
   status: UploadStatus;
   error: string | null;
   setStatus: (status: UploadStatus) => void;
   setStoreId: (storeId: string | null) => void;
+  setTaskId: (taskId: string | null) => void;
   setError: (error: string | null) => void;
 }
 
 export const useAppStore = create<AppState>((set) => ({
   storeId: null,
+  taskId: null,
   status: 'idle',
   error: null,
   setStatus: (status) => set({ status }),
   setStoreId: (storeId) => set({ storeId }),
+  setTaskId: (taskId) => set({ taskId }),
   setError: (error) => set({ error }),
 }));


### PR DESCRIPTION
## Summary
- add Supabase upload and task record creation
- track uploaded task id in Zustand store and FileUploader
- update tests for new task id handling
- include formidable dependency for parsing form data

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*