### PR TITLE
Add Vitest tests for Google Drive components

### DIFF
--- a/src/components/GoogleDriveBrowser.test.tsx
+++ b/src/components/GoogleDriveBrowser.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import GoogleDriveBrowser from './GoogleDriveBrowser';
+import { googleDriveService } from '@/services/googleDriveService';
+
+vi.mock('@/services/googleDriveService', () => ({
+  googleDriveService: {
+    listFiles: vi.fn()
+  }
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() })
+}));
+
+const mockListFiles = googleDriveService.listFiles as unknown as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('GoogleDriveBrowser', () => {
+  it('renders files from the API', async () => {
+    mockListFiles.mockResolvedValue({
+      files: [{ id: '1', name: 'MyFile', mimeType: 'text/plain' }],
+      currentFolderId: 'root'
+    });
+
+    render(<GoogleDriveBrowser />);
+
+    await waitFor(() => {
+      expect(screen.getByText('MyFile')).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty folder message when no files', async () => {
+    mockListFiles.mockResolvedValue({ files: [], currentFolderId: 'root' });
+
+    render(<GoogleDriveBrowser />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No files found in this folder')).toBeInTheDocument();
+    });
+  });
+
+  it('displays error and allows retry', async () => {
+    mockListFiles.mockRejectedValueOnce(new Error('API Error'));
+    mockListFiles.mockResolvedValueOnce({ files: [], currentFolderId: 'root' });
+
+    render(<GoogleDriveBrowser />);
+
+    await waitFor(() => {
+      expect(screen.getByText('API Error')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Try Again'));
+
+    await waitFor(() => {
+      expect(mockListFiles).toHaveBeenCalledTimes(2);
+      expect(screen.getByText('No files found in this folder')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/services/googleDriveService.test.ts
+++ b/src/services/googleDriveService.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { googleDriveService } from './googleDriveService';
+import { supabase } from '@/integrations/supabase/client';
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    functions: {
+      invoke: vi.fn()
+    }
+  }
+}));
+
+const mockInvoke = supabase.functions.invoke as unknown as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('googleDriveService.listFiles', () => {
+  it('returns files when API succeeds', async () => {
+    mockInvoke.mockResolvedValue({
+      data: { success: true, data: { files: [{ id: '1', name: 'Doc', mimeType: 'text/plain' }], currentFolderId: '1' } }
+    } as any);
+
+    const result = await googleDriveService.listFiles('1');
+    expect(result).toEqual({ files: [{ id: '1', name: 'Doc', mimeType: 'text/plain' }], currentFolderId: '1' });
+    expect(mockInvoke).toHaveBeenCalled();
+  });
+
+  it('returns empty list on invalid structure', async () => {
+    mockInvoke.mockResolvedValue({ data: { invalid: true } } as any);
+
+    const result = await googleDriveService.listFiles('root');
+    expect(result).toEqual({ files: [], currentFolderId: 'root' });
+  });
+
+  it('throws on API error', async () => {
+    mockInvoke.mockResolvedValue({ error: { message: 'fail' } } as any);
+
+    await expect(googleDriveService.listFiles('root')).rejects.toThrow('fail');
+  });
+});
+
+describe('googleDriveService.downloadFile', () => {
+  it('returns file data when API succeeds', async () => {
+    mockInvoke.mockResolvedValue({
+      data: {
+        success: true,
+        data: { id: 'f1', name: 'file.txt', mimeType: 'text/plain', content: 'abc' }
+      }
+    } as any);
+
+    const result = await googleDriveService.downloadFile('f1');
+    expect(result).toEqual({ id: 'f1', name: 'file.txt', mimeType: 'text/plain', content: 'abc' });
+  });
+
+  it('throws on invalid response structure', async () => {
+    mockInvoke.mockResolvedValue({ data: { success: false } } as any);
+
+    await expect(googleDriveService.downloadFile('f2')).rejects.toThrow('Invalid file download response structure');
+  });
+
+  it('throws on API error', async () => {
+    mockInvoke.mockResolvedValue({ error: { message: 'boom' } } as any);
+
+    await expect(googleDriveService.downloadFile('f2')).rejects.toThrow('boom');
+  });
+});


### PR DESCRIPTION
## Summary
- add component tests for `GoogleDriveBrowser`
- add service tests for `googleDriveService`

## Testing
- `npm ci` *(fails: EHOSTUNREACH)*
- `npm test` *(fails: vitest not found)*